### PR TITLE
Fix ArrowReaderOptions should read with physical_file_schema so we do…

### DIFF
--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -153,7 +153,7 @@ impl FileOpener for ParquetOpener {
                     metadata,
                     &mut reader,
                     // Since we're manually loading the page index the option here should not matter but we pass it in for consistency
-                    ArrowReaderOptions::new().with_page_index(true),
+                    ArrowReaderOptions::new().with_page_index(true).with_schema(physical_file_schema.clone()),
                 )
                 .await?;
             }

--- a/datafusion/datasource-parquet/src/opener.rs
+++ b/datafusion/datasource-parquet/src/opener.rs
@@ -153,7 +153,9 @@ impl FileOpener for ParquetOpener {
                     metadata,
                     &mut reader,
                     // Since we're manually loading the page index the option here should not matter but we pass it in for consistency
-                    ArrowReaderOptions::new().with_page_index(true).with_schema(physical_file_schema.clone()),
+                    ArrowReaderOptions::new()
+                        .with_page_index(true)
+                        .with_schema(physical_file_schema.clone()),
                 )
                 .await?;
             }


### PR DESCRIPTION
…n't need to cast back to utf8

## Which issue does this PR close?

Make the benchmark back to normal.

## Rationale for this change
Fix ArrowReaderOptions should read with physical_file_schema 

Make the benchmark back to normal.

## What changes are included in this PR?

Fix ArrowReaderOptions should read with physical_file_schema 
Make the benchmark back to normal.

## Are these changes tested?

Yes

## Are there any user-facing changes?

No
