### PR TITLE
Remove typedefs (e.g. `ExecutionPlanFilterPushdownResult`)

### DIFF
--- a/datafusion/core/tests/physical_optimizer/filter_pushdown.rs
+++ b/datafusion/core/tests/physical_optimizer/filter_pushdown.rs
@@ -30,9 +30,7 @@ use datafusion_common::{internal_err, Result};
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::source::DataSourceExec;
 use datafusion_datasource::{
-    file::{FileSource, FileSourceFilterPushdownResult},
-    file_scan_config::FileScanConfig,
-    file_stream::FileOpener,
+    file::FileSource, file_scan_config::FileScanConfig, file_stream::FileOpener,
 };
 use datafusion_expr::test::function_stub::count_udaf;
 use datafusion_physical_expr::expressions::col;
@@ -47,6 +45,7 @@ use datafusion_physical_plan::{
     coalesce_batches::CoalesceBatchesExec,
     filter::FilterExec,
     repartition::RepartitionExec,
+    FilterPushdownResult,
 };
 use datafusion_physical_plan::{
     displayable, filter_pushdown::FilterPushdownSupport,
@@ -150,7 +149,7 @@ impl FileSource for TestSource {
         &self,
         filters: &[PhysicalExprRef],
         config: &ConfigOptions,
-    ) -> Result<FileSourceFilterPushdownResult> {
+    ) -> Result<FilterPushdownResult<Arc<dyn FileSource>>> {
         let support = match self.support {
             Some(support) => support,
             None => {
@@ -166,10 +165,7 @@ impl FileSource for TestSource {
             predicate: Some(conjunction(filters.iter().map(Arc::clone))),
             statistics: self.statistics.clone(),
         });
-        Ok(FileSourceFilterPushdownResult::new(
-            new,
-            vec![support; filters.len()],
-        ))
+        Ok(FilterPushdownResult::new(new, vec![support; filters.len()]))
     }
 }
 

--- a/datafusion/datasource/src/file.rs
+++ b/datafusion/datasource/src/file.rs
@@ -103,9 +103,7 @@ pub trait FileSource: Send + Sync {
         &self,
         _filters: &[PhysicalExprRef],
         _config: &ConfigOptions,
-    ) -> Result<FileSourceFilterPushdownResult> {
-        Ok(FileSourceFilterPushdownResult::NotPushed)
+    ) -> Result<FilterPushdownResult<Arc<dyn FileSource>>> {
+        Ok(FilterPushdownResult::NotPushed)
     }
 }
-
-pub type FileSourceFilterPushdownResult = FilterPushdownResult<Arc<dyn FileSource>>;

--- a/datafusion/datasource/src/file_scan_config.rs
+++ b/datafusion/datasource/src/file_scan_config.rs
@@ -46,20 +46,20 @@ use datafusion_physical_plan::{
     display::{display_orderings, ProjectSchemaDisplay},
     metrics::ExecutionPlanMetricsSet,
     projection::{all_alias_free_columns, new_projections_for_columns, ProjectionExec},
-    DisplayAs, DisplayFormatType, ExecutionPlan,
+    DisplayAs, DisplayFormatType, ExecutionPlan, FilterPushdownResult,
 };
 use log::{debug, warn};
 
+use crate::file_groups::FileGroup;
 use crate::{
     display::FileGroupsDisplay,
-    file::{FileSource, FileSourceFilterPushdownResult},
+    file::FileSource,
     file_compression_type::FileCompressionType,
     file_stream::FileStream,
     source::{DataSource, DataSourceExec},
     statistics::MinMaxStatistics,
     PartitionedFile,
 };
-use crate::{file_groups::FileGroup, source::DataSourceFilterPushdownResult};
 
 /// The base configurations for a [`DataSourceExec`], the a physical plan for
 /// any given file format.
@@ -591,18 +591,16 @@ impl DataSource for FileScanConfig {
         &self,
         filters: &[PhysicalExprRef],
         config: &ConfigOptions,
-    ) -> Result<DataSourceFilterPushdownResult> {
+    ) -> Result<FilterPushdownResult<Arc<dyn DataSource>>> {
         match self.file_source.try_pushdown_filters(filters, config)? {
-            FileSourceFilterPushdownResult::NotPushed => {
-                Ok(DataSourceFilterPushdownResult::NotPushed)
-            }
-            FileSourceFilterPushdownResult::Pushed { inner, support } => {
+            FilterPushdownResult::NotPushed => Ok(FilterPushdownResult::NotPushed),
+            FilterPushdownResult::Pushed { inner, support } => {
                 let new_self = Arc::new(
                     FileScanConfigBuilder::from(self.clone())
                         .with_source(inner)
                         .build(),
                 );
-                Ok(DataSourceFilterPushdownResult::Pushed {
+                Ok(FilterPushdownResult::Pushed {
                     inner: new_self,
                     support,
                 })

--- a/datafusion/datasource/src/source.rs
+++ b/datafusion/datasource/src/source.rs
@@ -26,8 +26,7 @@ use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion_physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion_physical_plan::projection::ProjectionExec;
 use datafusion_physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanFilterPushdownResult,
-    FilterPushdownResult, PlanProperties,
+    DisplayAs, DisplayFormatType, ExecutionPlan, FilterPushdownResult, PlanProperties,
 };
 
 use crate::file_scan_config::FileScanConfig;
@@ -210,17 +209,17 @@ impl ExecutionPlan for DataSourceExec {
         _plan: &Arc<dyn ExecutionPlan>,
         parent_filters: &[PhysicalExprRef],
         config: &ConfigOptions,
-    ) -> Result<ExecutionPlanFilterPushdownResult> {
+    ) -> Result<FilterPushdownResult<Arc<dyn ExecutionPlan>>> {
         match self
             .data_source
             .try_pushdown_filters(parent_filters, config)?
         {
             DataSourceFilterPushdownResult::NotPushed => {
-                Ok(ExecutionPlanFilterPushdownResult::NotPushed)
+                Ok(FilterPushdownResult::NotPushed)
             }
             DataSourceFilterPushdownResult::Pushed { inner, support } => {
                 let new_self = Arc::new(DataSourceExec::new(inner));
-                Ok(ExecutionPlanFilterPushdownResult::Pushed {
+                Ok(FilterPushdownResult::Pushed {
                     inner: new_self,
                     support,
                 })

--- a/datafusion/physical-optimizer/src/filter_pushdown.rs
+++ b/datafusion/physical-optimizer/src/filter_pushdown.rs
@@ -18,9 +18,7 @@
 use std::sync::Arc;
 
 use datafusion_common::{config::ConfigOptions, DataFusionError, Result};
-use datafusion_physical_plan::{
-    execution_plan::ExecutionPlanFilterPushdownResult, ExecutionPlan,
-};
+use datafusion_physical_plan::{ExecutionPlan, FilterPushdownResult};
 
 use crate::PhysicalOptimizerRule;
 
@@ -48,8 +46,8 @@ impl PhysicalOptimizerRule for PushdownFilter {
         config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         match plan.try_pushdown_filters(&plan, &Vec::new(), config)? {
-            ExecutionPlanFilterPushdownResult::NotPushed => Ok(plan),
-            ExecutionPlanFilterPushdownResult::Pushed { inner, support } => {
+            FilterPushdownResult::NotPushed => Ok(plan),
+            FilterPushdownResult::Pushed { inner, support } => {
                 if !support.is_empty() {
                     return Err(
                         DataFusionError::Plan(

--- a/datafusion/physical-plan/src/coalesce_batches.rs
+++ b/datafusion/physical-plan/src/coalesce_batches.rs
@@ -23,7 +23,9 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use super::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
-use super::{DisplayAs, ExecutionPlanProperties, PlanProperties, Statistics};
+use super::{
+    DisplayAs, ExecutionPlanProperties, FilterPushdownResult, PlanProperties, Statistics,
+};
 use crate::{
     DisplayFormatType, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
 };
@@ -219,7 +221,7 @@ impl ExecutionPlan for CoalesceBatchesExec {
         plan: &Arc<dyn ExecutionPlan>,
         parent_filters: &[datafusion_physical_expr::PhysicalExprRef],
         config: &ConfigOptions,
-    ) -> Result<crate::ExecutionPlanFilterPushdownResult> {
+    ) -> Result<FilterPushdownResult<Arc<dyn ExecutionPlan>>> {
         try_pushdown_filters_to_input(plan, &self.input, parent_filters, config)
     }
 }

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -43,8 +43,7 @@ pub use crate::display::{DefaultDisplay, DisplayAs, DisplayFormatType, VerboseDi
 pub use crate::execution_plan::{
     collect, collect_partitioned, displayable, execute_input_stream, execute_stream,
     execute_stream_partitioned, get_plan_string, with_new_children_if_necessary,
-    ExecutionPlan, ExecutionPlanFilterPushdownResult, ExecutionPlanProperties,
-    PlanProperties,
+    ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
 pub use crate::filter_pushdown::FilterPushdownResult;
 pub use crate::metrics::Metric;

--- a/datafusion/physical-plan/src/repartition/mod.rs
+++ b/datafusion/physical-plan/src/repartition/mod.rs
@@ -27,7 +27,8 @@ use std::{any::Any, vec};
 use super::common::SharedMemoryReservation;
 use super::metrics::{self, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
 use super::{
-    DisplayAs, ExecutionPlanProperties, RecordBatchStream, SendableRecordBatchStream,
+    DisplayAs, ExecutionPlanProperties, FilterPushdownResult, RecordBatchStream,
+    SendableRecordBatchStream,
 };
 use crate::execution_plan::{try_pushdown_filters_to_input, CardinalityEffect};
 use crate::hash_utils::create_hashes;
@@ -730,7 +731,7 @@ impl ExecutionPlan for RepartitionExec {
         plan: &Arc<dyn ExecutionPlan>,
         parent_filters: &[datafusion_physical_expr::PhysicalExprRef],
         config: &ConfigOptions,
-    ) -> Result<crate::ExecutionPlanFilterPushdownResult> {
+    ) -> Result<FilterPushdownResult<Arc<dyn ExecutionPlan>>> {
         try_pushdown_filters_to_input(plan, &self.input, parent_filters, config)
     }
 }


### PR DESCRIPTION
Targets https://github.com/apache/datafusion/pull/15566

Here is a proposal to simplify the APIs. 

In my opinion a typedef in Rust just adds cognitive overhead and makes the code harder to read. If we need a new type we should make a real struct with documentation, etc. A typedef just adds an extra layer of indirection. 

I also think this change makes the code simpler 

Both of these are subjective opinions