### PR TITLE
Add slt test for pushing volatile predicates down

### DIFF
--- a/datafusion/sqllogictest/test_files/parquet_filter_pushdown.slt
+++ b/datafusion/sqllogictest/test_files/parquet_filter_pushdown.slt
@@ -405,6 +405,21 @@ physical_plan
 02)--SortExec: expr=[b@0 ASC NULLS LAST], preserve_partitioning=[true]
 03)----DataSourceExec: file_groups={2 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet_filter_pushdown/parquet_table/1.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet_filter_pushdown/parquet_table/2.parquet]]}, projection=[b], file_type=parquet, predicate=a@0 = bar, pruning_predicate=a_null_count@2 != row_count@3 AND a_min@0 <= bar AND bar <= a_max@1, required_guarantees=[a in (bar)]
 
+
+# should not push down volatile predicates such as RANDOM
+# expect that the random predicate is evaluated after the scan
+query TT
+EXPLAIN select a from t_pushdown where b > random();
+----
+logical_plan
+01)Projection: t_pushdown.a
+02)--Filter: CAST(t_pushdown.b AS Float64) > random()
+03)----TableScan: t_pushdown projection=[a, b]
+physical_plan
+01)CoalesceBatchesExec: target_batch_size=8192
+02)--FilterExec: CAST(b@1 AS Float64) > random(), projection=[a@0]
+03)----DataSourceExec: file_groups={2 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet_filter_pushdown/parquet_table/1.parquet], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/parquet_filter_pushdown/parquet_table/2.parquet]]}, projection=[a, b], file_type=parquet
+
 ## cleanup
 statement ok
 DROP TABLE t;


### PR DESCRIPTION
## Which issue does this PR close?

- Targets https://github.com/apache/datafusion/pull/16861 

Merging this PR will update https://github.com/apache/datafusion/pull/16861 

## Rationale for this change

I think we should have a slt "end to end" reproducer for (not) pushing down volatile predicates

## What changes are included in this PR?
Add a slt test
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

Only tests
## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
