### PR TITLE
fix: apply struct field filters when the file schema needs adaptation

### DIFF
--- a/datafusion/datasource-parquet/src/opener/mod.rs
+++ b/datafusion/datasource-parquet/src/opener/mod.rs
@@ -3761,4 +3761,109 @@ mod test {
             assert_eq!(rows, 5);
         }
     }
+
+    /// Filters on struct fields (`s['x'] = 200`) must still be applied when the
+    /// table schema disagrees with the physical file schema, which forces the
+    /// expression adapter to insert a cast.
+    ///
+    /// See <https://github.com/apache/datafusion/issues/24109>.
+    mod struct_field_pushdown {
+        use super::*;
+        use arrow::array::{Int32Array, StructArray};
+        use arrow::datatypes::Fields;
+        use datafusion_functions::core::get_field;
+
+        /// Writes `s: Struct<x: Int32>` with `x` values 100, 200, 300 and
+        /// returns the physical file schema plus the written file.
+        async fn write_struct_file(
+            store: &Arc<dyn ObjectStore>,
+            path: &str,
+        ) -> (SchemaRef, PartitionedFile) {
+            let physical_struct_fields: Fields =
+                vec![Field::new("x", DataType::Int32, true)].into();
+            let struct_array = StructArray::new(
+                physical_struct_fields.clone(),
+                vec![Arc::new(Int32Array::from(vec![100, 200, 300])) as _],
+                None,
+            );
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "s",
+                DataType::Struct(physical_struct_fields),
+                true,
+            )]));
+            let batch = RecordBatch::try_new(
+                Arc::clone(&schema),
+                vec![Arc::new(struct_array) as _],
+            )
+            .unwrap();
+            let data_size = write_parquet(Arc::clone(store), path, batch).await;
+            let file =
+                PartitionedFile::new(path.to_string(), u64::try_from(data_size).unwrap());
+            (schema, file)
+        }
+
+        /// `s: Struct<x: Int64>` — the same column as on disk, but with a
+        /// wider leaf type so the adapter has to insert a cast.
+        fn logical_schema() -> SchemaRef {
+            Arc::new(Schema::new(vec![Field::new(
+                "s",
+                DataType::Struct(vec![Field::new("x", DataType::Int64, true)].into()),
+                true,
+            )]))
+        }
+
+        fn struct_field_eq(
+            schema: &SchemaRef,
+            value: ScalarValue,
+        ) -> Arc<dyn PhysicalExpr> {
+            let expr = get_field().call(vec![col("s"), lit("x")]).eq(lit(value));
+            logical2physical(&expr, schema)
+        }
+
+        #[tokio::test]
+        async fn test_struct_field_filter_with_schema_adaptation() {
+            let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+            let (_physical_schema, file) =
+                write_struct_file(&store, "struct_cast.parquet").await;
+            let logical_schema = logical_schema();
+
+            let opener = ParquetMorselizerBuilder::new()
+                .with_store(Arc::clone(&store))
+                .with_schema(Arc::clone(&logical_schema))
+                .with_projection_indices(&[0])
+                .with_predicate(struct_field_eq(
+                    &logical_schema,
+                    ScalarValue::Int64(Some(200)),
+                ))
+                .with_pushdown_filters(true)
+                .build();
+
+            let stream = open_file(&opener, file).await.unwrap();
+            let (_batches, rows) = count_batches_and_rows(stream).await;
+            assert_eq!(rows, 1, "predicate on struct field must be applied");
+        }
+
+        /// Control: with matching schemas the filter has always worked.
+        #[tokio::test]
+        async fn test_struct_field_filter_without_schema_adaptation() {
+            let store = Arc::new(InMemory::new()) as Arc<dyn ObjectStore>;
+            let (physical_schema, file) =
+                write_struct_file(&store, "struct_nocast.parquet").await;
+
+            let opener = ParquetMorselizerBuilder::new()
+                .with_store(Arc::clone(&store))
+                .with_schema(Arc::clone(&physical_schema))
+                .with_projection_indices(&[0])
+                .with_predicate(struct_field_eq(
+                    &physical_schema,
+                    ScalarValue::Int32(Some(200)),
+                ))
+                .with_pushdown_filters(true)
+                .build();
+
+            let stream = open_file(&opener, file).await.unwrap();
+            let (_batches, rows) = count_batches_and_rows(stream).await;
+            assert_eq!(rows, 1);
+        }
+    }
 }

--- a/datafusion/physical-expr-adapter/src/schema_rewriter.rs
+++ b/datafusion/physical-expr-adapter/src/schema_rewriter.rs
@@ -25,7 +25,7 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
-use arrow::datatypes::{DataType, FieldRef, SchemaRef};
+use arrow::datatypes::{DataType, FieldRef, Fields, SchemaRef};
 use datafusion_common::{
     DataFusionError, Result, ScalarValue, exec_err,
     metadata::FieldMetadata,
@@ -273,6 +273,35 @@ struct DefaultPhysicalExprAdapterRewriter {
     physical_file_schema: SchemaRef,
 }
 
+/// Outcome of walking a `get_field` key path through nested struct fields.
+enum FieldPathResolution<'a> {
+    /// The leaf field the path points at.
+    Found(&'a FieldRef),
+    /// Some key along the path does not exist, so the access reads as null.
+    Missing,
+    /// An intermediate field is not a struct, so the path cannot be resolved
+    /// statically.
+    NotAStruct,
+}
+
+/// Follow a `get_field` key path (`['a', 'b']` for `s['a']['b']`) through
+/// nested struct fields.
+fn resolve_field_path<'a>(fields: &'a Fields, path: &[&str]) -> FieldPathResolution<'a> {
+    let Some((field_name, rest)) = path.split_first() else {
+        return FieldPathResolution::NotAStruct;
+    };
+    let Some(field) = fields.iter().find(|f| f.name() == field_name) else {
+        return FieldPathResolution::Missing;
+    };
+    if rest.is_empty() {
+        return FieldPathResolution::Found(field);
+    }
+    match field.data_type() {
+        DataType::Struct(nested_fields) => resolve_field_path(nested_fields, rest),
+        _ => FieldPathResolution::NotAStruct,
+    }
+}
+
 impl DefaultPhysicalExprAdapterRewriter {
     fn rewrite_expr(
         &self,
@@ -310,6 +339,10 @@ impl DefaultPhysicalExprAdapterRewriter {
     ///
     /// See <https://github.com/apache/datafusion/issues/24109>.
     ///
+    /// `get_field` also has a flattened multi-key form: `s['a']['b']` is
+    /// simplified to `get_field(s, 'a', 'b')`, so the whole field path is
+    /// resolved here rather than just the first key.
+    ///
     /// Only struct casts are narrowed. `get_field` on a Map column performs a
     /// runtime key lookup rather than a schema-level field access, so the map
     /// value must keep its cast.
@@ -322,25 +355,36 @@ impl DefaultPhysicalExprAdapterRewriter {
         else {
             return Ok(None);
         };
-        let [source_expr, field_name_expr] = get_field_expr.args() else {
-            return Ok(None);
-        };
-        let Some(cast) = source_expr.downcast_ref::<CastExpr>() else {
-            return Ok(None);
-        };
-        let Some(field_name) = field_name_expr
-            .downcast_ref::<Literal>()
-            .and_then(|lit| lit.value().try_as_str().flatten())
+        let Some((source_expr, field_name_exprs)) = get_field_expr.args().split_first()
         else {
             return Ok(None);
         };
+        if field_name_exprs.is_empty() {
+            return Ok(None);
+        }
+        let Some(cast) = source_expr.downcast_ref::<CastExpr>() else {
+            return Ok(None);
+        };
+
+        // Every key has to be a string literal, otherwise the leaf field
+        // cannot be resolved statically.
+        let mut field_path = Vec::with_capacity(field_name_exprs.len());
+        for field_name_expr in field_name_exprs {
+            let Some(field_name) = field_name_expr
+                .downcast_ref::<Literal>()
+                .and_then(|lit| lit.value().try_as_str().flatten())
+            else {
+                return Ok(None);
+            };
+            field_path.push(field_name);
+        }
+
         let DataType::Struct(logical_struct_fields) = cast.target_field().data_type()
         else {
             return Ok(None);
         };
-        let Some(logical_struct_field) = logical_struct_fields
-            .iter()
-            .find(|f| f.name() == field_name)
+        let FieldPathResolution::Found(logical_struct_field) =
+            resolve_field_path(logical_struct_fields, &field_path)
         else {
             return Ok(None);
         };
@@ -351,26 +395,32 @@ impl DefaultPhysicalExprAdapterRewriter {
         else {
             return Ok(None);
         };
-        let Some(physical_struct_field) = physical_struct_fields
-            .iter()
-            .find(|f| f.name() == field_name)
-        else {
-            // The file does not have this field at all, so reading it yields
-            // null. Note that the cast would have produced the same value:
-            // struct casts fill missing target fields with nulls.
-            let null_value =
-                ScalarValue::Null.cast_to(logical_struct_field.data_type())?;
-            return Ok(Some(Arc::new(Literal::new_with_metadata(
-                null_value,
-                Some(FieldMetadata::from(logical_struct_field.as_ref())),
-            ))));
-        };
+        let physical_struct_field =
+            match resolve_field_path(&physical_struct_fields, &field_path) {
+                FieldPathResolution::Found(field) => field,
+                FieldPathResolution::Missing => {
+                    // The file does not have this field at all, so reading it
+                    // yields null. Note that the cast would have produced the
+                    // same value: struct casts fill missing target fields with
+                    // nulls.
+                    let null_value =
+                        ScalarValue::Null.cast_to(logical_struct_field.data_type())?;
+                    return Ok(Some(Arc::new(Literal::new_with_metadata(
+                        null_value,
+                        Some(FieldMetadata::from(logical_struct_field.as_ref())),
+                    ))));
+                }
+                FieldPathResolution::NotAStruct => return Ok(None),
+            };
 
         // Rebuild `get_field` over the uncast struct so its return field is
         // recomputed from the physical field type.
+        let mut args = Vec::with_capacity(get_field_expr.args().len());
+        args.push(Arc::clone(inner));
+        args.extend(field_name_exprs.iter().map(Arc::clone));
         let extracted = Arc::new(ScalarFunctionExpr::try_new(
             Arc::new(get_field_expr.fun().clone()),
-            vec![Arc::clone(inner), Arc::clone(field_name_expr)],
+            args,
             &self.physical_file_schema,
             Arc::new(get_field_expr.config_options().clone()),
         )?) as Arc<dyn PhysicalExpr>;
@@ -1638,6 +1688,108 @@ mod tests {
             inner_get_field.args()[0].downcast_ref::<Column>().is_some(),
             "the struct column must not be hidden behind a cast, got: {rewritten}"
         );
+    }
+
+    /// `s['inner']['x']` is simplified to the flattened `get_field(s, 'inner',
+    /// 'x')`, so the whole key path has to be resolved.
+    #[test]
+    fn test_narrow_struct_cast_flattened_field_path() {
+        let (logical_schema, physical_schema) = struct_schemas(
+            vec![Field::new(
+                "inner",
+                DataType::Struct(vec![Field::new("x", DataType::Utf8, true)].into()),
+                true,
+            )],
+            vec![Field::new(
+                "inner",
+                DataType::Struct(vec![Field::new("x", DataType::Utf8View, true)].into()),
+                true,
+            )],
+        );
+
+        let adapter = DefaultPhysicalExprAdapterFactory
+            .create(Arc::clone(&logical_schema), physical_schema)
+            .unwrap();
+        let expr = Arc::new(
+            ScalarFunctionExpr::try_new(
+                Arc::new(datafusion_expr::ScalarUDF::from(GetFieldFunc::new())),
+                vec![
+                    Arc::new(Column::new("s", 0)),
+                    Arc::new(Literal::new(ScalarValue::from("inner"))),
+                    Arc::new(Literal::new(ScalarValue::from("x"))),
+                ],
+                &logical_schema,
+                Arc::new(datafusion_common::config::ConfigOptions::default()),
+            )
+            .unwrap(),
+        ) as Arc<dyn PhysicalExpr>;
+
+        let rewritten = adapter.rewrite(expr).unwrap();
+
+        let cast = assert_cast_expr(&rewritten);
+        assert_eq!(cast.cast_type(), &DataType::Utf8View);
+        let get_field = cast
+            .expr()
+            .downcast_ref::<ScalarFunctionExpr>()
+            .expect("Expected get_field under the cast");
+        assert_eq!(get_field.return_type(), &DataType::Utf8);
+        assert_eq!(
+            get_field.args().len(),
+            3,
+            "the full key path must be preserved, got: {rewritten}"
+        );
+        assert!(
+            get_field.args()[0].downcast_ref::<Column>().is_some(),
+            "the struct column must not be hidden behind a cast, got: {rewritten}"
+        );
+    }
+
+    /// A key path whose leaf is missing from the file still resolves to a
+    /// typed null literal.
+    #[test]
+    fn test_narrow_struct_cast_flattened_field_path_missing_leaf() {
+        let (logical_schema, physical_schema) = struct_schemas(
+            vec![Field::new(
+                "inner",
+                DataType::Struct(vec![Field::new("x", DataType::Int32, true)].into()),
+                true,
+            )],
+            vec![Field::new(
+                "inner",
+                DataType::Struct(
+                    vec![
+                        Field::new("x", DataType::Int32, true),
+                        Field::new("y", DataType::Utf8, true),
+                    ]
+                    .into(),
+                ),
+                true,
+            )],
+        );
+
+        let adapter = DefaultPhysicalExprAdapterFactory
+            .create(Arc::clone(&logical_schema), physical_schema)
+            .unwrap();
+        let expr = Arc::new(
+            ScalarFunctionExpr::try_new(
+                Arc::new(datafusion_expr::ScalarUDF::from(GetFieldFunc::new())),
+                vec![
+                    Arc::new(Column::new("s", 0)),
+                    Arc::new(Literal::new(ScalarValue::from("inner"))),
+                    Arc::new(Literal::new(ScalarValue::from("y"))),
+                ],
+                &logical_schema,
+                Arc::new(datafusion_common::config::ConfigOptions::default()),
+            )
+            .unwrap(),
+        ) as Arc<dyn PhysicalExpr>;
+
+        let rewritten = adapter.rewrite(expr).unwrap();
+
+        let literal = rewritten
+            .downcast_ref::<Literal>()
+            .expect("Expected a null literal");
+        assert_eq!(*literal.value(), ScalarValue::Utf8(None));
     }
 
     /// Accessing a field the file does not have yields a typed null literal.

--- a/datafusion/physical-expr-adapter/src/schema_rewriter.rs
+++ b/datafusion/physical-expr-adapter/src/schema_rewriter.rs
@@ -282,11 +282,107 @@ impl DefaultPhysicalExprAdapterRewriter {
             return Ok(Transformed::yes(transformed));
         }
 
+        if let Some(transformed) = self.try_narrow_struct_cast(&expr)? {
+            return Ok(Transformed::yes(transformed));
+        }
+
         if let Some(column) = expr.downcast_ref::<Column>() {
             return self.rewrite_column(Arc::clone(&expr), column);
         }
 
         Ok(Transformed::no(expr))
+    }
+
+    /// Rewrite `get_field(cast(s AS Struct<..>), 'f')` into
+    /// `cast(get_field(s, 'f') AS <type of f>)`.
+    ///
+    /// Expressions are rewritten bottom-up, so by the time we reach a
+    /// `get_field` node its struct argument has already been wrapped in a cast
+    /// by [`Self::rewrite_column`] whenever the logical and physical struct
+    /// types differ. Casting the whole struct just to read one field is
+    /// wasteful, and — more importantly — it hides the underlying column from
+    /// consumers that pattern match on `get_field(column, 'f')`. The Parquet
+    /// scan is one such consumer: it decides at planning time (against the
+    /// table schema) that a struct-field predicate can be evaluated as a row
+    /// filter, then fails to build that row filter at runtime because the
+    /// adapted expression no longer has a bare column under the `get_field`,
+    /// silently dropping the predicate and returning unfiltered rows.
+    ///
+    /// See <https://github.com/apache/datafusion/issues/24109>.
+    ///
+    /// Only struct casts are narrowed. `get_field` on a Map column performs a
+    /// runtime key lookup rather than a schema-level field access, so the map
+    /// value must keep its cast.
+    fn try_narrow_struct_cast(
+        &self,
+        expr: &Arc<dyn PhysicalExpr>,
+    ) -> Result<Option<Arc<dyn PhysicalExpr>>> {
+        let Some(get_field_expr) =
+            ScalarFunctionExpr::try_downcast_func::<GetFieldFunc>(expr.as_ref())
+        else {
+            return Ok(None);
+        };
+        let [source_expr, field_name_expr] = get_field_expr.args() else {
+            return Ok(None);
+        };
+        let Some(cast) = source_expr.downcast_ref::<CastExpr>() else {
+            return Ok(None);
+        };
+        let Some(field_name) = field_name_expr
+            .downcast_ref::<Literal>()
+            .and_then(|lit| lit.value().try_as_str().flatten())
+        else {
+            return Ok(None);
+        };
+        let DataType::Struct(logical_struct_fields) = cast.target_field().data_type()
+        else {
+            return Ok(None);
+        };
+        let Some(logical_struct_field) = logical_struct_fields
+            .iter()
+            .find(|f| f.name() == field_name)
+        else {
+            return Ok(None);
+        };
+
+        let inner = cast.expr();
+        let DataType::Struct(physical_struct_fields) =
+            inner.data_type(&self.physical_file_schema)?
+        else {
+            return Ok(None);
+        };
+        let Some(physical_struct_field) = physical_struct_fields
+            .iter()
+            .find(|f| f.name() == field_name)
+        else {
+            // The file does not have this field at all, so reading it yields
+            // null. Note that the cast would have produced the same value:
+            // struct casts fill missing target fields with nulls.
+            let null_value =
+                ScalarValue::Null.cast_to(logical_struct_field.data_type())?;
+            return Ok(Some(Arc::new(Literal::new_with_metadata(
+                null_value,
+                Some(FieldMetadata::from(logical_struct_field.as_ref())),
+            ))));
+        };
+
+        // Rebuild `get_field` over the uncast struct so its return field is
+        // recomputed from the physical field type.
+        let extracted = Arc::new(ScalarFunctionExpr::try_new(
+            Arc::new(get_field_expr.fun().clone()),
+            vec![Arc::clone(inner), Arc::clone(field_name_expr)],
+            &self.physical_file_schema,
+            Arc::new(get_field_expr.config_options().clone()),
+        )?) as Arc<dyn PhysicalExpr>;
+
+        if physical_struct_field == logical_struct_field {
+            return Ok(Some(extracted));
+        }
+        Ok(Some(Arc::new(CastExpr::new_with_target_field(
+            extracted,
+            Arc::clone(logical_struct_field),
+            Some(cast.cast_options().clone()),
+        ))))
     }
 
     /// Attempt to rewrite struct field access expressions to return null if the field does not exist in the physical schema.
@@ -1424,6 +1520,195 @@ mod tests {
         // The actual test for the get_field expression would require creating a proper ScalarFunctionExpr
         // with ScalarUDF, which is complex to set up in a unit test. The integration tests in
         // datafusion/core/tests/parquet/schema_adapter.rs provide better coverage for this functionality.
+    }
+
+    /// Build `get_field(column, 'field')` against `schema`.
+    fn get_field_expr(
+        schema: &Schema,
+        column: &str,
+        field: &str,
+    ) -> Arc<dyn PhysicalExpr> {
+        let index = schema.index_of(column).unwrap();
+        Arc::new(
+            ScalarFunctionExpr::try_new(
+                Arc::new(datafusion_expr::ScalarUDF::from(GetFieldFunc::new())),
+                vec![
+                    Arc::new(Column::new(column, index)),
+                    Arc::new(Literal::new(ScalarValue::from(field))),
+                ],
+                schema,
+                Arc::new(datafusion_common::config::ConfigOptions::default()),
+            )
+            .unwrap(),
+        )
+    }
+
+    fn struct_schemas(
+        physical_fields: Vec<Field>,
+        logical_fields: Vec<Field>,
+    ) -> (SchemaRef, SchemaRef) {
+        let physical = Arc::new(Schema::new(vec![Field::new(
+            "s",
+            DataType::Struct(physical_fields.into()),
+            true,
+        )]));
+        let logical = Arc::new(Schema::new(vec![Field::new(
+            "s",
+            DataType::Struct(logical_fields.into()),
+            true,
+        )]));
+        (logical, physical)
+    }
+
+    /// `s['x']` where the file stores `x` as `Int32` and the table declares
+    /// `Int64` must cast the extracted field, not the whole struct, so that
+    /// the column stays visible under the `get_field`.
+    ///
+    /// See <https://github.com/apache/datafusion/issues/24109>.
+    #[test]
+    fn test_narrow_struct_cast_to_field_access() {
+        let (logical_schema, physical_schema) = struct_schemas(
+            vec![Field::new("x", DataType::Int32, true)],
+            vec![Field::new("x", DataType::Int64, true)],
+        );
+
+        let adapter = DefaultPhysicalExprAdapterFactory
+            .create(Arc::clone(&logical_schema), physical_schema)
+            .unwrap();
+        let rewritten = adapter
+            .rewrite(get_field_expr(&logical_schema, "s", "x"))
+            .unwrap();
+
+        let cast = assert_cast_expr(&rewritten);
+        assert_eq!(cast.cast_type(), &DataType::Int64);
+        let get_field = cast
+            .expr()
+            .downcast_ref::<ScalarFunctionExpr>()
+            .expect("Expected get_field under the cast");
+        assert_eq!(get_field.return_type(), &DataType::Int32);
+        assert!(
+            get_field.args()[0].downcast_ref::<Column>().is_some(),
+            "the struct column must not be hidden behind a cast, got: {rewritten}"
+        );
+    }
+
+    /// A struct field that only differs in a nested leaf type still ends up
+    /// with a single cast on the extracted field.
+    #[test]
+    fn test_narrow_struct_cast_nested_field_access() {
+        let (logical_schema, physical_schema) = struct_schemas(
+            vec![Field::new(
+                "inner",
+                DataType::Struct(vec![Field::new("x", DataType::Utf8, true)].into()),
+                true,
+            )],
+            vec![Field::new(
+                "inner",
+                DataType::Struct(vec![Field::new("x", DataType::Utf8View, true)].into()),
+                true,
+            )],
+        );
+
+        let adapter = DefaultPhysicalExprAdapterFactory
+            .create(Arc::clone(&logical_schema), physical_schema)
+            .unwrap();
+        let outer = get_field_expr(&logical_schema, "s", "inner");
+        let expr = Arc::new(
+            ScalarFunctionExpr::try_new(
+                Arc::new(datafusion_expr::ScalarUDF::from(GetFieldFunc::new())),
+                vec![outer, Arc::new(Literal::new(ScalarValue::from("x")))],
+                &logical_schema,
+                Arc::new(datafusion_common::config::ConfigOptions::default()),
+            )
+            .unwrap(),
+        ) as Arc<dyn PhysicalExpr>;
+
+        let rewritten = adapter.rewrite(expr).unwrap();
+
+        let cast = assert_cast_expr(&rewritten);
+        assert_eq!(cast.cast_type(), &DataType::Utf8View);
+        let outer_get_field = cast
+            .expr()
+            .downcast_ref::<ScalarFunctionExpr>()
+            .expect("Expected get_field under the cast");
+        let inner_get_field = outer_get_field.args()[0]
+            .downcast_ref::<ScalarFunctionExpr>()
+            .expect("Expected a nested get_field");
+        assert!(
+            inner_get_field.args()[0].downcast_ref::<Column>().is_some(),
+            "the struct column must not be hidden behind a cast, got: {rewritten}"
+        );
+    }
+
+    /// Accessing a field the file does not have yields a typed null literal.
+    #[test]
+    fn test_narrow_struct_cast_missing_field() {
+        let (logical_schema, physical_schema) = struct_schemas(
+            vec![Field::new("x", DataType::Int32, true)],
+            vec![
+                Field::new("x", DataType::Int32, true),
+                Field::new("y", DataType::Utf8, true),
+            ],
+        );
+
+        let adapter = DefaultPhysicalExprAdapterFactory
+            .create(Arc::clone(&logical_schema), physical_schema)
+            .unwrap();
+        let rewritten = adapter
+            .rewrite(get_field_expr(&logical_schema, "s", "y"))
+            .unwrap();
+
+        let literal = rewritten
+            .downcast_ref::<Literal>()
+            .expect("Expected a null literal");
+        assert_eq!(*literal.value(), ScalarValue::Utf8(None));
+    }
+
+    /// `get_field` on a Map column is a runtime key lookup, not a schema-level
+    /// field access, so the map value must keep its cast.
+    #[test]
+    fn test_map_field_access_keeps_cast() {
+        let map_type = |value_type: DataType| {
+            DataType::Map(
+                Arc::new(Field::new(
+                    "entries",
+                    DataType::Struct(
+                        vec![
+                            Field::new("keys", DataType::Utf8, false),
+                            Field::new("values", value_type, true),
+                        ]
+                        .into(),
+                    ),
+                    false,
+                )),
+                false,
+            )
+        };
+        let physical_schema = Arc::new(Schema::new(vec![Field::new(
+            "s",
+            map_type(DataType::Int32),
+            true,
+        )]));
+        let logical_schema = Arc::new(Schema::new(vec![Field::new(
+            "s",
+            map_type(DataType::Int64),
+            true,
+        )]));
+
+        let adapter = DefaultPhysicalExprAdapterFactory
+            .create(Arc::clone(&logical_schema), physical_schema)
+            .unwrap();
+        let rewritten = adapter
+            .rewrite(get_field_expr(&logical_schema, "s", "k"))
+            .unwrap();
+
+        let get_field = rewritten
+            .downcast_ref::<ScalarFunctionExpr>()
+            .expect("Expected the get_field to be preserved");
+        assert!(
+            get_field.args()[0].downcast_ref::<CastExpr>().is_some(),
+            "map columns must keep the whole-column cast, got: {rewritten}"
+        );
     }
 
     // ============================================================================

--- a/datafusion/sqllogictest/test_files/parquet_filter_pushdown.slt
+++ b/datafusion/sqllogictest/test_files/parquet_filter_pushdown.slt
@@ -930,12 +930,36 @@ SELECT id, s['x'] FROM t_struct_schema_cast WHERE s['x'] > 100 AND id > 2;
 ----
 3 300
 
+# Same, for a nested field path. `s['inner']['x']` is simplified to the
+# flattened `get_field(s, 'inner', 'x')`, which takes a different code path.
+statement ok
+COPY (
+  SELECT
+    column1 as id,
+    named_struct('inner', named_struct('x', arrow_cast(column2, 'Int32'))) as s
+  FROM VALUES (1, 100), (2, 200), (3, 300)
+) TO 'test_files/scratch/parquet_filter_pushdown/struct_nested_schema_cast.parquet'
+STORED AS PARQUET;
+
+statement ok
+CREATE EXTERNAL TABLE t_struct_nested_schema_cast (id BIGINT, s STRUCT<inner STRUCT<x BIGINT>>)
+STORED AS PARQUET
+LOCATION 'test_files/scratch/parquet_filter_pushdown/struct_nested_schema_cast.parquet';
+
+query II
+SELECT id, s['inner']['x'] FROM t_struct_nested_schema_cast WHERE s['inner']['x'] = 200;
+----
+2 200
+
 # Clean up
 statement ok
 set datafusion.execution.parquet.pushdown_filters = false;
 
 statement ok
 DROP TABLE t_struct_schema_cast;
+
+statement ok
+DROP TABLE t_struct_nested_schema_cast;
 
 ##########
 # Regression test for https://github.com/apache/datafusion/issues/20937

--- a/datafusion/sqllogictest/test_files/parquet_filter_pushdown.slt
+++ b/datafusion/sqllogictest/test_files/parquet_filter_pushdown.slt
@@ -891,6 +891,53 @@ statement ok
 DROP TABLE t_struct_filter;
 
 ##########
+# Regression test for https://github.com/apache/datafusion/issues/24109
+#
+# When the declared table schema differs from the physical file schema, the
+# expression adapter inserts a cast. Casting the whole struct column hid the
+# column from the row filter builder: the scan reported `s['x'] = 200` as
+# fully handled (so `FilterExec` was removed from the plan) but then could not
+# build the row filter, silently dropping the predicate and returning all rows.
+##########
+
+statement ok
+set datafusion.execution.parquet.pushdown_filters = true;
+
+statement ok
+COPY (
+  SELECT
+    column1 as id,
+    named_struct('x', arrow_cast(column2, 'Int32')) as s
+  FROM VALUES (1, 100), (2, 200), (3, 300)
+) TO 'test_files/scratch/parquet_filter_pushdown/struct_schema_cast.parquet'
+STORED AS PARQUET;
+
+# `x` is stored as Int32 in the file but declared as BIGINT here, which forces
+# the scan to adapt the struct column.
+statement ok
+CREATE EXTERNAL TABLE t_struct_schema_cast (id BIGINT, s STRUCT<x BIGINT>)
+STORED AS PARQUET
+LOCATION 'test_files/scratch/parquet_filter_pushdown/struct_schema_cast.parquet';
+
+query II
+SELECT id, s['x'] FROM t_struct_schema_cast WHERE s['x'] = 200;
+----
+2 200
+
+# Conjunction of a struct-field filter and a primitive filter.
+query II
+SELECT id, s['x'] FROM t_struct_schema_cast WHERE s['x'] > 100 AND id > 2;
+----
+3 300
+
+# Clean up
+statement ok
+set datafusion.execution.parquet.pushdown_filters = false;
+
+statement ok
+DROP TABLE t_struct_schema_cast;
+
+##########
 # Regression test for https://github.com/apache/datafusion/issues/20937
 #
 # Dynamic filter pushdown fails when joining VALUES against


### PR DESCRIPTION
## Which issue does this PR close?

- Closes https://github.com/apache/datafusion/issues/24109.

## Rationale for this change

With `datafusion.execution.parquet.pushdown_filters = true`, a filter on a struct field returns **all rows** when the declared table schema differs from the physical file schema for that column:

```sql
-- file stores s as Struct<x: Int32>, table declares Struct<x: BIGINT>
SELECT id, s['x'] FROM t WHERE s['x'] = 200;
-- returns 3 rows instead of 1
```

The planning-time decision and the runtime construction disagree:

1. `ParquetSource::try_pushdown_filters` evaluates `can_expr_be_pushed_down_with_schemas` against the **table** schema. `get_field(s, 'x')` has a bare column under the `get_field`, so it reports the predicate as fully handled and `FilterExec` is removed from the plan.
2. At open time the expression adapter rewrites the predicate against the **file** schema. Because the struct types differ, `rewrite_column` wraps the whole column in a cast, giving `get_field(cast(s AS Struct<x: Int64>), 'x')`.
3. `PushdownChecker` only recognizes `get_field` whose first argument is a `Column`. It now sees a `CastExpr`, falls through to normal traversal, hits the struct `Column`, and rejects pushdown — so no row filter is built and the conjunct is silently dropped.

Nothing applies the predicate, and the scan returns unfiltered rows.

## What changes are included in this PR?

Narrow the cast to the field that is actually read, in `DefaultPhysicalExprAdapter`:

```
get_field(cast(s AS Struct<x: Int64>), 'x')  ->  cast(get_field(s, 'x') AS Int64)
```

Expressions are rewritten bottom-up, so the new `try_narrow_struct_cast` matches the `get_field` node after its struct argument has already been wrapped, and rebuilds the `get_field` over the uncast struct (recomputing its return field from the physical field type) with the cast moved outside. This keeps the column visible under the `get_field`, so the Parquet row filter builder makes good on what planning promised.

Two details worth calling out:

- A field that is missing from the file collapses to a typed null literal, matching what the struct cast would have produced (DataFusion's struct casts match by name and fill missing target fields with nulls).
- `get_field` on a `Map` column is a runtime key lookup rather than a schema-level field access, so map values keep the whole-column cast.

As a side effect this also avoids materializing an entire cast struct just to read one field, which is a small win for any struct-field access over an evolved schema — not only for filters.

### Not addressed here

The issue also raises the broader concern that "a static determination made at planning time about what the scan can do, and the runtime construction that has to make good on it, are computed by different code against different schemas, and there is no mechanism forcing them to agree." This PR fixes the reported wrong-results bug; it does not add a mechanism (e.g. post-decode filtering in `ParquetOpener`) that would make any future divergence safe by construction. That seems worth doing separately.

## Are these changes tested?

Yes.

- `datafusion/physical-expr-adapter/src/schema_rewriter.rs`: unit tests for the narrowed cast (flat and nested field access), the missing-field null literal, and that Map columns keep their cast.
- `datafusion/datasource-parquet/src/opener/mod.rs`: end-to-end opener tests reading a `Struct<x: Int32>` file through a `Struct<x: Int64>` table schema with pushdown enabled, plus a matching-schema control.
- `datafusion/sqllogictest/test_files/parquet_filter_pushdown.slt`: a SQL-level regression test. Verified that it fails on `main` (returns all 3 rows) and passes with the fix.

Full runs: `cargo clippy --all-targets --all-features -- -D warnings`, the complete sqllogictest suite (498 files), `datafusion-physical-expr-adapter`, `datafusion-datasource-parquet`, and the `datafusion` `core_integration` / `parquet_integration` suites all pass.

## Are there any user-facing changes?

A wrong-results bug fix: struct-field predicates are now applied when the scan needs schema adaptation. No public API changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MebN5PsVnYvXUeVKju5K7P)_