### PR TITLE
docs: update proto-models README for the datafusion-common dependency

### DIFF
--- a/datafusion/proto-models/README.md
+++ b/datafusion/proto-models/README.md
@@ -22,9 +22,17 @@
 [Apache DataFusion] is an extensible query execution framework, written in Rust, that uses [Apache Arrow] as its in-memory format.
 
 This crate contains the [prost]-generated Rust types for DataFusion's logical
-and physical plan protobuf schemas. It is intentionally kept narrow: it has no
-DataFusion dependencies beyond [`datafusion-proto-common`] and exposes only the
-generated structs (and optional [pbjson]/[serde] support).
+and physical plan protobuf schemas, plus the `From` / `TryFrom` conversions
+between those types and the [`datafusion-common`] types they mirror. The
+conversions live here because their DataFusion side sits _below_ this crate in
+the dependency graph and so cannot host the impls itself — the same arrangement
+[`datafusion-proto-common`] uses for `ScalarValue` and `Statistics`.
+
+It is otherwise intentionally kept narrow: its only DataFusion dependencies are
+[`datafusion-common`] and [`datafusion-proto-common`], and apart from those
+conversions it exposes only the generated structs (and optional
+[pbjson]/[serde] support). In particular it does not depend on
+`datafusion-expr` or on any of the execution crates.
 
 This crate is consumed by [`datafusion-proto`] and may also be depended on
 directly by other DataFusion crates that need to refer to the proto schema
@@ -39,5 +47,6 @@ crate, there is no reason to use this crate directly in your project as well.
 [prost]: https://docs.rs/prost/latest/prost/
 [pbjson]: https://docs.rs/pbjson/latest/pbjson/
 [serde]: https://serde.rs/
+[`datafusion-common`]: https://crates.io/crates/datafusion-common
 [`datafusion-proto`]: https://crates.io/crates/datafusion-proto
 [`datafusion-proto-common`]: https://crates.io/crates/datafusion-proto-common


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up to the review comment on apache/datafusion#24205: https://github.com/apache/datafusion/pull/24205#discussion_r3760772294

No separate issue.

## Rationale for this change

apache/datafusion#24205 ("Restore the `From` / `TryFrom` proto conversions dropped since 54.1.0") adds a direct `datafusion-common` dependency to `datafusion-proto-models` and puts the `From` / `TryFrom` impls in the crate. `datafusion/proto-models/README.md` was not updated alongside it, so it now says the opposite of what is true:

> It is intentionally kept narrow: it has no DataFusion dependencies beyond `datafusion-proto-common` and exposes only the generated structs (and optional pbjson/serde support).

@timsaucer flagged this on the Cargo.toml change; the reply there was that it would be handled as a follow-up. That's this PR.

The crate's `lib.rs` docs were already updated in #24205 — this brings the README in line with them.

## What changes are included in this PR?

`datafusion/proto-models/README.md` only:

- The crate's contents now include the `From` / `TryFrom` conversions between the generated proto types and the `datafusion-common` types they mirror, with the reason those impls live here (the DataFusion side sits below this crate in the dependency graph, mirroring how `datafusion-proto-common` handles `ScalarValue` and `Statistics`).
- Restated the narrowness claim accurately: `datafusion-common` and `datafusion-proto-common` are the only DataFusion dependencies, and no `datafusion-expr` or execution crates.
- Added the `datafusion-common` crates.io link definition.

Note: this is written against the post-#24205 state of the crate, so it should be reviewed/merged **after** #24205 lands. It's based on `main` rather than stacked on that branch, so it does not depend on it mechanically and will not conflict.

## Are these changes tested?

Not applicable — documentation only. `./ci/scripts/doc_prettier_check.sh` passes (it made no changes to the file).

## Are there any user-facing changes?

Documentation only; no API or behavior changes. The corrected text is user-facing in the sense that this README is the crate's rendered description on crates.io.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoAdfGfHwhLreDPDQ9GoDK)_